### PR TITLE
Fixed passing Hashes to send or request

### DIFF
--- a/lib/ezmq/publish.rb
+++ b/lib/ezmq/publish.rb
@@ -25,7 +25,7 @@ module EZMQ
     #
     # @return [Fixnum] the size of the message.
     #
-    def send(message = '', topic: '', **options)
+    def send(message, topic: '', **options)
       message = "#{ topic } #{ (options[:encode] || @encode).call message }"
       @socket.send_string message
     end

--- a/lib/ezmq/request.rb
+++ b/lib/ezmq/request.rb
@@ -25,7 +25,7 @@ module EZMQ
     #
     # @return [void] the decoded response message.
     #
-    def request(message = '', **options)
+    def request(message, **options)
       send message, options
       if block_given?
         yield receive options

--- a/tests/ezmq/pair.rb
+++ b/tests/ezmq/pair.rb
@@ -20,7 +20,6 @@ context 'Paired sockets' do
   should 'pass Hash messages to the encode method' do
     @connected.encode = -> m { assert_equal({message: 'test'}, m) }
     @connected.send message: 'test'
-    @connected.encode = -> m { m }
   end
 
   should 'yield the contents of messages they receive, if given a block' do

--- a/tests/ezmq/publish.rb
+++ b/tests/ezmq/publish.rb
@@ -16,4 +16,9 @@ context 'Publishers' do
   should 'return the length of messages they send (with a topic)' do
     assert_equal 8, @publisher.send('message')
   end
+
+  should 'pass Hash messages to the encode method' do
+    @client.encode = -> m { assert_equal({message: 'test'}, m) }
+    @client.request message: 'test'
+  end
 end

--- a/tests/ezmq/publish.rb
+++ b/tests/ezmq/publish.rb
@@ -18,7 +18,7 @@ context 'Publishers' do
   end
 
   should 'pass Hash messages to the encode method' do
-    @client.encode = -> m { assert_equal({message: 'test'}, m) }
-    @client.request message: 'test'
+    @publisher.encode = -> m { assert_equal({message: 'test'}, m) }
+    @publisher.send message: 'test'
   end
 end

--- a/tests/ezmq/request.rb
+++ b/tests/ezmq/request.rb
@@ -25,4 +25,9 @@ context 'Clients' do
   should 'yield the contents of reply, if given a block' do
     assert_equal 'message', @client.request('message') { |m| m }
   end
+
+  should 'pass Hash messages to the encode method' do
+    @client.encode = -> m { assert_equal({message: 'test'}, m) }
+    @client.request message: 'test'
+  end
 end


### PR DESCRIPTION
I was getting the same problems as last time but for `Client.request`. I looked into it, found the same root problem of message defaults confusing Ruby, and replaced it anywhere I found `message = ''`.
